### PR TITLE
Biped Implementation

### DIFF
--- a/pronto_biped_commons/CMakeLists.txt
+++ b/pronto_biped_commons/CMakeLists.txt
@@ -10,13 +10,14 @@ find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   tf_conversions
   pronto_biped_core
+  tf2_eigen
 )
 find_package(Eigen3 REQUIRED)
 
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
-  CATKIN_DEPENDS roscpp geometry_msgs tf_conversions pronto_biped_core
+  CATKIN_DEPENDS roscpp geometry_msgs tf_conversions pronto_biped_core tf2_eigen
   DEPENDS EIGEN3
 )
 

--- a/pronto_biped_commons/CMakeLists.txt
+++ b/pronto_biped_commons/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.0.2)
+project(pronto_biped_commons)
+
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Find catkin and other dependencies
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  geometry_msgs
+  tf_conversions
+  pronto_biped_core
+)
+find_package(Eigen3 REQUIRED)
+
+catkin_package(
+  INCLUDE_DIRS include
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS roscpp geometry_msgs tf_conversions pronto_biped_core
+  DEPENDS EIGEN3
+)
+
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  ${EIGEN3_INCLUDE_DIRS}
+)
+
+# Build the library from your source file
+add_library(${PROJECT_NAME}
+  src/forward_kinematics.cpp
+)
+
+add_dependencies(${PROJECT_NAME} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(${PROJECT_NAME}
+  ${catkin_LIBRARIES}
+  ${EIGEN3_LIBRARIES}
+)
+
+# Install targets and header files
+install(TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+  RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+)
+
+install(DIRECTORY include/${PROJECT_NAME}/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING PATTERN "*.hpp"
+)

--- a/pronto_biped_commons/include/pronto_biped_commons/forward_kinematics.hpp
+++ b/pronto_biped_commons/include/pronto_biped_commons/forward_kinematics.hpp
@@ -1,0 +1,40 @@
+#pragma once
+#include <geometry_msgs/PoseStamped.h>
+#include <pronto_msgs/BipedCartesianPoses.h>
+#include <ros/ros.h>
+#include <Eigen/Geometry>
+#include <mutex>
+#include <pronto_biped_core/biped_forward_kinematics.hpp>
+
+namespace pronto {
+namespace biped {
+
+class BipedForwardKinematicsExternal : public BipedForwardKinematics {
+ public:
+  using Transform = Eigen::Isometry3d;
+
+  BipedForwardKinematicsExternal(const ros::NodeHandle& nh);
+
+  // Implement the pure virtual functions from the base class:
+  Transform getLeftFootPose(const JointState& q) override;
+  Transform getRightFootPose(const JointState& q) override;
+
+  bool getLeftFootPose(const JointState& q, Transform& x) override;
+  bool getRightFootPose(const JointState& q, Transform& x) override;
+
+ private:
+  void footPosesCallback(const pronto_msgs::BipedCartesianPosesConstPtr& msg);
+
+  ros::NodeHandle nh_;
+  ros::Subscriber foot_pose_sub_;
+
+  // store the latest foot pose
+  std::mutex mtx_;
+  Transform left_foot_pose_;
+  Transform right_foot_pose_;
+  bool left_received_ = false;
+  bool right_received_ = false;
+};
+
+}  // namespace biped
+}  // namespace pronto

--- a/pronto_biped_commons/package.xml
+++ b/pronto_biped_commons/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>pronto_biped_commons</name>
+  <version>0.0.1</version>
+  <description>
+    This package provides forward kinematics functionality for the biped, including
+    the external forward kinematics implementation.
+  </description>
+
+  <maintainer email="you@example.com">Your Name</maintainer>
+  <license>BSD</license>
+
+  <!-- Build tool dependency -->
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <!-- Build dependencies -->
+  <build_depend>roscpp</build_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>tf_conversions</build_depend>
+  <build_depend>pronto_biped_core</build_depend>
+  <build_depend>eigen_conversions</build_depend> <!-- Optional, if needed -->
+
+  <!-- Execution dependencies -->
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>tf_conversions</exec_depend>
+  <exec_depend>pronto_biped_core</exec_depend>
+
+  <export>
+    <build_type>catkin</build_type>
+  </export>
+</package>

--- a/pronto_biped_commons/package.xml
+++ b/pronto_biped_commons/package.xml
@@ -18,13 +18,14 @@
   <build_depend>geometry_msgs</build_depend>
   <build_depend>tf_conversions</build_depend>
   <build_depend>pronto_biped_core</build_depend>
-  <build_depend>eigen_conversions</build_depend> <!-- Optional, if needed -->
+  <build_depend>tf2_eigen</build_depend>
 
   <!-- Execution dependencies -->
   <exec_depend>roscpp</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>tf_conversions</exec_depend>
   <exec_depend>pronto_biped_core</exec_depend>
+  <exec_depend>tf2_eigen</exec_depend>
 
   <export>
     <build_type>catkin</build_type>

--- a/pronto_biped_commons/src/forward_kinematics.cpp
+++ b/pronto_biped_commons/src/forward_kinematics.cpp
@@ -28,27 +28,22 @@ void BipedForwardKinematicsExternal::footPosesCallback(
 
   // Loop through each CartesianPose in the message.
   for (const auto& cp : msg->cartesian_poses) {
+    Eigen::Isometry3d iso;
+    tf2::fromMsg(cp.cartesian_pose.pose, iso);
     // Check joint_id: 15 for left foot, 16 for right foot.
     if (cp.joint_id == 15) {
-      tf::Transform tf_transform;
-      tf::poseMsgToTF(cp.cartesian_pose.pose, tf_transform);
-      Eigen::Isometry3d iso;
-      tf::poseTFToEigen(tf_transform, iso);
       left_foot_pose_ = iso;
       left_found = true;
     } else if (cp.joint_id == 16) {
-      tf::Transform tf_transform;
-      tf::poseMsgToTF(cp.cartesian_pose.pose, tf_transform);
-      Eigen::Isometry3d iso;
-      tf::poseTFToEigen(tf_transform, iso);
       right_foot_pose_ = iso;
       right_found = true;
     }
+
+    if (left_found && right_found)
+      break;
   }
-  if (left_found)
-    left_received_ = true;
-  if (right_found)
-    right_received_ = true;
+  if (left_found) left_received_ = true;
+  if (right_found) right_received_ = true;
 }
 
 bool BipedForwardKinematicsExternal::getLeftFootPose(

--- a/pronto_biped_commons/src/forward_kinematics.cpp
+++ b/pronto_biped_commons/src/forward_kinematics.cpp
@@ -1,15 +1,20 @@
 #include "pronto_biped_commons/forward_kinematics.hpp"
 #include <tf/transform_datatypes.h>
 #include <tf_conversions/tf_eigen.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
 
 namespace pronto {
 namespace biped {
+
+// Define constants for the foot joint IDs. These depend on the URDF
+static const int LEFT_FOOT_JOINT_ID = 15;
+static const int RIGHT_FOOT_JOINT_ID = 16;
 
 BipedForwardKinematicsExternal::BipedForwardKinematicsExternal(
     const ros::NodeHandle& nh)
     : nh_(nh) {
   foot_pose_sub_ =
-      nh_.subscribe("/biped/estimated_cartesian_poses", 1,
+      nh_.subscribe("/biped/cartesian_poses", 1,
                     &BipedForwardKinematicsExternal::footPosesCallback, this);
 
   // Initialize the stored poses to identity
@@ -19,22 +24,21 @@ BipedForwardKinematicsExternal::BipedForwardKinematicsExternal(
   right_received_ = false;
 }
 
-// Callback for BipedCartesianPoses messages.
+// Callback for BipedCartesianPoses messages
 void BipedForwardKinematicsExternal::footPosesCallback(
     const pronto_msgs::BipedCartesianPosesConstPtr& msg) {
   std::lock_guard<std::mutex> lock(mtx_);
   bool left_found = false;
   bool right_found = false;
 
-  // Loop through each CartesianPose in the message.
+  // Loop through each CartesianPose in the message
   for (const auto& cp : msg->cartesian_poses) {
     Eigen::Isometry3d iso;
     tf2::fromMsg(cp.cartesian_pose.pose, iso);
-    // Check joint_id: 15 for left foot, 16 for right foot.
-    if (cp.joint_id == 15) {
+    if (cp.joint_id == LEFT_FOOT_JOINT_ID) {
       left_foot_pose_ = iso;
       left_found = true;
-    } else if (cp.joint_id == 16) {
+    } else if (cp.joint_id == RIGHT_FOOT_JOINT_ID) {
       right_foot_pose_ = iso;
       right_found = true;
     }

--- a/pronto_biped_commons/src/forward_kinematics.cpp
+++ b/pronto_biped_commons/src/forward_kinematics.cpp
@@ -1,7 +1,7 @@
 #include "pronto_biped_commons/forward_kinematics.hpp"
 #include <tf/transform_datatypes.h>
 #include <tf_conversions/tf_eigen.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_eigen/tf2_eigen.h>
 
 namespace pronto {
 namespace biped {

--- a/pronto_biped_commons/src/forward_kinematics.cpp
+++ b/pronto_biped_commons/src/forward_kinematics.cpp
@@ -1,0 +1,95 @@
+#include "pronto_biped_commons/forward_kinematics.hpp"
+#include <tf/transform_datatypes.h>
+#include <tf_conversions/tf_eigen.h>
+
+namespace pronto {
+namespace biped {
+
+BipedForwardKinematicsExternal::BipedForwardKinematicsExternal(
+    const ros::NodeHandle& nh)
+    : nh_(nh) {
+  foot_pose_sub_ =
+      nh_.subscribe("/biped/estimated_cartesian_poses", 1,
+                    &BipedForwardKinematicsExternal::footPosesCallback, this);
+
+  // Initialize the stored poses to identity
+  left_foot_pose_.setIdentity();
+  right_foot_pose_.setIdentity();
+  left_received_ = false;
+  right_received_ = false;
+}
+
+// Callback for BipedCartesianPoses messages.
+void BipedForwardKinematicsExternal::footPosesCallback(
+    const pronto_msgs::BipedCartesianPosesConstPtr& msg) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  bool left_found = false;
+  bool right_found = false;
+
+  // Loop through each CartesianPose in the message.
+  for (const auto& cp : msg->cartesian_poses) {
+    // Check joint_id: 15 for left foot, 16 for right foot.
+    if (cp.joint_id == 15) {
+      tf::Transform tf_transform;
+      tf::poseMsgToTF(cp.cartesian_pose.pose, tf_transform);
+      Eigen::Isometry3d iso;
+      tf::poseTFToEigen(tf_transform, iso);
+      left_foot_pose_ = iso;
+      left_found = true;
+    } else if (cp.joint_id == 16) {
+      tf::Transform tf_transform;
+      tf::poseMsgToTF(cp.cartesian_pose.pose, tf_transform);
+      Eigen::Isometry3d iso;
+      tf::poseTFToEigen(tf_transform, iso);
+      right_foot_pose_ = iso;
+      right_found = true;
+    }
+  }
+  if (left_found)
+    left_received_ = true;
+  if (right_found)
+    right_received_ = true;
+}
+
+bool BipedForwardKinematicsExternal::getLeftFootPose(
+    const BipedForwardKinematicsExternal::JointState& q,
+    BipedForwardKinematicsExternal::Transform& x) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  if (!left_received_)
+    return false;
+  x = left_foot_pose_;
+  return true;
+}
+
+bool BipedForwardKinematicsExternal::getRightFootPose(
+    const BipedForwardKinematicsExternal::JointState& q,
+    BipedForwardKinematicsExternal::Transform& x) {
+  std::lock_guard<std::mutex> lock(mtx_);
+  if (!right_received_)
+    return false;
+  x = right_foot_pose_;
+  return true;
+}
+
+BipedForwardKinematicsExternal::Transform
+BipedForwardKinematicsExternal::getLeftFootPose(
+    const BipedForwardKinematicsExternal::JointState& q) {
+  BipedForwardKinematicsExternal::Transform x;
+  if (getLeftFootPose(q, x))
+    return x;
+  else
+    return BipedForwardKinematicsExternal::Transform::Identity();
+}
+
+BipedForwardKinematicsExternal::Transform
+BipedForwardKinematicsExternal::getRightFootPose(
+    const BipedForwardKinematicsExternal::JointState& q) {
+  BipedForwardKinematicsExternal::Transform x;
+  if (getRightFootPose(q, x))
+    return x;
+  else
+    return BipedForwardKinematicsExternal::Transform::Identity();
+}
+
+}  // namespace biped
+}  // namespace pronto

--- a/pronto_biped_core/CMakeLists.txt
+++ b/pronto_biped_core/CMakeLists.txt
@@ -4,7 +4,8 @@ project(pronto_biped_core)
 set(CMAKE_CXX_STANDARD 14)
 
 find_package(catkin REQUIRED COMPONENTS pronto_utils
-                                        pronto_core)
+                                        pronto_core
+                                        pronto_msgs)
 
 
 set(LEGODO_LIB_NAME pronto_biped_legodo)
@@ -12,7 +13,8 @@ set(LEGODO_LIB_NAME pronto_biped_legodo)
 catkin_package(INCLUDE_DIRS include
                LIBRARIES ${LEGODO_LIB_NAME}
                CATKIN_DEPENDS pronto_utils
-                              pronto_core)
+                              pronto_core
+                              pronto_msgs)
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 

--- a/pronto_biped_core/include/pronto_biped_core/leg_estimate.hpp
+++ b/pronto_biped_core/include/pronto_biped_core/leg_estimate.hpp
@@ -59,8 +59,8 @@ public:
       n_control_contacts_right_ = n_control_contacts_right_in;
     }
 
-    inline void setForwardKinematics(const Eigen::Isometry3d& left,
-                                     const Eigen::Isometry3d& right);
+    void setForwardKinematics(const Eigen::Isometry3d& left,
+                              const Eigen::Isometry3d& right);
     
     // Update the running leg odometry solution
     // returns: odometry_status - a foot contact classification

--- a/pronto_biped_core/include/pronto_biped_core/legodo_module.hpp
+++ b/pronto_biped_core/include/pronto_biped_core/legodo_module.hpp
@@ -4,7 +4,7 @@
 #include <pronto_core/definitions.hpp>
 #include "pronto_biped_core/leg_estimate.hpp"
 #include "pronto_biped_core/legodo_common.hpp"
-#include "pronto_biped_core/biped_forward_kinematics.hpp"
+#include "pronto_msgs/BipedCartesianPoses.h"
 #include <pronto_utils/torque_adjustment.hpp> // torque adjustment
 
 namespace pronto {
@@ -21,7 +21,7 @@ struct LegOdometryConfig {
 
 class LegOdometryModule : SensingModule<JointState> {
 public:
-    LegOdometryModule(BipedForwardKinematics& fk, const LegOdometryConfig& cfg);
+    LegOdometryModule(const LegOdometryConfig& cfg);
 
     RBISUpdateInterface* processMessage(const JointState *msg,
                                         StateEstimator *est);
@@ -38,7 +38,14 @@ public:
 
     void setForceTorque(const ForceTorqueSensorArray& array);
 
+    void updateForwardKinematics(const pronto_msgs::BipedCartesianPoses& fk_msg);
 
+    int getPrimaryFootID() const {
+        if (leg_est_) {
+        return leg_est_->getPrimaryFootID();
+        }
+        return -1;
+    }
 
 protected:
     std::shared_ptr<LegEstimator> leg_est_;

--- a/pronto_biped_core/package.xml
+++ b/pronto_biped_core/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <depend>pronto_utils</depend>
   <depend>pronto_core</depend>
+  <depend>pronto_msgs</depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export />

--- a/pronto_biped_core/src/FootContactAlt.cpp
+++ b/pronto_biped_core/src/FootContactAlt.cpp
@@ -40,7 +40,7 @@ FootContactAlt::FootContactAlt(bool _log_data_files,
   left_contact_state_strong_->forceHigh();
   right_contact_state_strong_->forceHigh();
   
-  verbose_ =1; // 3 lots, 2 some, 1 v.important
+  verbose_ = -1; // 3 lots, 2 some, 1 v.important
 }
 
 

--- a/pronto_biped_core/src/foot_contact_classify.cpp
+++ b/pronto_biped_core/src/foot_contact_classify.cpp
@@ -217,7 +217,7 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
         if (verbose_ >= 3) std::cout << pv << ">0 | primary left. both in contact. still [LEFT_PRIME_RIGHT_STAND]\n";
         return 2;
       } else {
-        std::cout << "Unknown LEFT_PRIME_RIGHT_STAND Transition: " << pv<< "\n";
+        if (verbose_ >= 1) std::cout << "Unknown LEFT_PRIME_RIGHT_STAND Transition: " << pv<< "\n";
         return -2;
       }
       break;
@@ -235,7 +235,7 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
         if (verbose_ >= 3) std::cout << pv << ">1 | primary left still in contact but right weak. still\n";
         return -1;
       }else{
-        std::cout << "Unknown LEFT_PRIME_RIGHT_BREAK Transition: " << pv<< "\n";
+        if (verbose_ >= 1) std::cout << "Unknown LEFT_PRIME_RIGHT_BREAK Transition: " << pv<< "\n";
         return -2;
       }
       break;
@@ -253,7 +253,7 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
         if (verbose_ >= 1) std::cout << pv << ">2 | Error: neither foot in contact! Staying in [LEFT_PRIME_RIGHT_SWING]\n";
         return 2;
       }else{
-        std::cout << "Unknown LEFT_PRIME_RIGHT_SWING Transition: " << pv<< "\n";
+        if (verbose_ >= 1) std::cout << "Unknown LEFT_PRIME_RIGHT_SWING Transition: " << pv<< "\n";
         return -2;
       }
       break;
@@ -266,7 +266,7 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
         if (verbose_ >= 3) std::cout << pv << ">3 | primary left. right weak. still [LEFT_PRIME_RIGHT_STRIKE] \n";
         return -1;
       }else{
-        std::cout << "Unknown LEFT_PRIME_RIGHT_STRIKE Transition: " << pv<< "\n";
+        if (verbose_ >= 1) std::cout << "Unknown LEFT_PRIME_RIGHT_STRIKE Transition: " << pv<< "\n";
         return -2;
       }
       break;
@@ -285,7 +285,7 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
         if (verbose_ >= 3) std::cout << pv << ">4 | primary left. both in contact. still [LEFT_STAND_RIGHT_PRIME]\n";
         return 2;
       }else{
-        std::cout << "Unknown LEFT_STAND_RIGHT_PRIME Transition: " << pv<< "\n";
+        if (verbose_ >= 1) std::cout << "Unknown LEFT_STAND_RIGHT_PRIME Transition: " << pv<< "\n";
         return -2;
       }
       break;
@@ -302,7 +302,7 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
         if (verbose_ >= 3) std::cout << pv << ">5 | primary right. left weak. still [LEFT_BREAK_RIGHT_PRIME]\n";
         return -1;
       }else{
-        std::cout << "Unknown LEFT_BREAK_RIGHT_PRIME Transition: " << pv<< "\n";
+        if (verbose_ >= 1) std::cout << "Unknown LEFT_BREAK_RIGHT_PRIME Transition: " << pv<< "\n";
         return -2;
       }
       break;
@@ -320,7 +320,7 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
         if (verbose_ >= 1) std::cout << pv << ">6 | Error: neither foot in contact! Staying in [LEFT_SWING_RIGHT_PRIME]\n";
         return 3;
       }else{
-        std::cout << "Unknown LEFT_SWING_RIGHT_PRIME Transition: " << pv<< "\n";
+        if (verbose_ >= 1) std::cout << "Unknown LEFT_SWING_RIGHT_PRIME Transition: " << pv<< "\n";
         return -2;
       }
       break;
@@ -333,7 +333,7 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
         if (verbose_ >= 3) std::cout << pv << ">7 | primary right. left weak. still [LEFT_STRIKE_RIGHT_PRIME] \n";
         return -1;
       }else{
-        std::cout << "Unknown LEFT_STRIKE_RIGHT_PRIME Transition: " << pv<< "\n";
+        if (verbose_ >= 1) std::cout << "Unknown LEFT_STRIKE_RIGHT_PRIME Transition: " << pv<< "\n";
         return -2;
       }
       break;

--- a/pronto_biped_core/src/foot_contact_classify.cpp
+++ b/pronto_biped_core/src/foot_contact_classify.cpp
@@ -19,7 +19,7 @@ FootContactClassifier::FootContactClassifier(bool publish_diagnostics_) :
   initialized_ = false;
   mode_ = WalkMode::UNKNOWN;
   previous_mode_ = WalkMode::UNKNOWN;
-  verbose_ = 3; // 3 lots, 2 some, 1 v.important, 0 typical for debug, -1 typical for operation
+  verbose_ = -1; // 3 lots, 2 some, 1 v.important, 0 typical for debug, -1 typical for operation
 
   // defaults dehann used: 0, 5, 5000 but foot doesnt 'hang' like in VRC
   left_contact_state_weak_  = new SchmittTrigger(20.0, 30.0, 5000, 5000);

--- a/pronto_biped_core/src/foot_contact_classify.cpp
+++ b/pronto_biped_core/src/foot_contact_classify.cpp
@@ -187,12 +187,12 @@ int FootContactClassifier::updateWalkingPhase(int64_t utime,
 
   if (!initialized_){
     if (left_contact && right_contact){
-      std::cout << pv << ">0 | Initializing. both in contact with left foot as primary\n";
+      if (verbose_ >= 1) std::cout << pv << ">0 | Initializing. both in contact with left foot as primary\n";
       mode_ = WalkMode::LEFT_PRIME_RIGHT_STAND;
       initialized_ = true;
       return 2;
     }else{
-      std::cout << pv << ">8 | Not initialized yet: both feet are not in contact\n";
+      if (verbose_ >= 1) std::cout << pv << ">8 | Not initialized yet: both feet are not in contact\n";
       return -1;
     }
   }

--- a/pronto_biped_core/src/leg_estimate.cpp
+++ b/pronto_biped_core/src/leg_estimate.cpp
@@ -312,7 +312,7 @@ bool LegEstimator::legOdometryGravitySlavedAlways(const Eigen::Isometry3d& body_
     odom_to_secondary_foot_ = odom_to_body_ * body_to_r_foot;
     primary_foot_ = FootID::LEFT;
   }else{
-    std::cout << "initialized but unknown update: " << static_cast<int>(contact_status) << " and " << (int) primary_foot_ << "\n";
+    if (verbose_>1) std::cout << "initialized but unknown update: " << static_cast<int>(contact_status) << " and " << (int) primary_foot_ << "\n";
   }
 
   return init_this_iteration;

--- a/pronto_biped_core/src/leg_estimate.cpp
+++ b/pronto_biped_core/src/leg_estimate.cpp
@@ -120,7 +120,7 @@ LegEstimator::LegEstimator(const LegOdometerConfig& cfg) :
   //TODO class names with CamelCase: FootContactClassifier
   foot_contact_classify_.reset(new FootContactClassifier(publish_diagnostics_));
 
-  verbose_ = 1;
+  verbose_ = -1;
 
   previous_utime_ = 0; // Set utimes to known values
   current_utime_ = 0;
@@ -264,7 +264,7 @@ bool LegEstimator::legOdometryGravitySlavedAlways(const Eigen::Isometry3d& body_
     odom_to_body_ = odom_to_primary_foot_fixed_ * body_to_l_foot.inverse() ;
     odom_to_secondary_foot_ = odom_to_body_ * body_to_r_foot;
   }else if (contact_status == ContactStatusID::RIGHT_NEW && primary_foot_ == FootID::LEFT){
-    std::cout << "2 Transition Odometry to right foot. Fix foot, update pelvis position\n";
+    if (verbose_>1) std::cout << "2 Transition Odometry to right foot. Fix foot, update pelvis position\n";
     // When transitioning, take the passive position of the other foot
     // from the previous iteration. this will now be the fixed foot
     // At the instant of transition, slave the pelvis position to gravity:
@@ -296,7 +296,7 @@ bool LegEstimator::legOdometryGravitySlavedAlways(const Eigen::Isometry3d& body_
     odom_to_body_ = odom_to_primary_foot_fixed_ * body_to_r_foot.inverse() ;
     odom_to_secondary_foot_ = odom_to_body_ * body_to_l_foot;
   }else if (contact_status == ContactStatusID::LEFT_NEW && primary_foot_ == FootID::RIGHT){
-    std::cout << "2 Transition Odometry to left foot. Fix foot, update pelvis position\n";
+    if (verbose_>1) std::cout << "2 Transition Odometry to left foot. Fix foot, update pelvis position\n";
 
     // When transitioning, take the passive position of the other foot
     // from the previous iteration. this will now be the fixed foot
@@ -504,7 +504,7 @@ float LegEstimator::updateOdometry(const std::vector<std::string>& joint_name,
 
     if ((contact_status == ContactStatusID::LEFT_NEW) || (contact_status == ContactStatusID::RIGHT_NEW) )
     {
-      std::cout << "3 Leg Estimate: Changing Foot Constraint\n";
+      if (verbose_>1) std::cout << "3 Leg Estimate: Changing Foot Constraint\n";
       world_to_primary_foot_transition_ = world_to_primary_foot_slide_;
       world_to_primary_foot_transition_init_ = true;
       if (publish_diagnostics_) { // this was enabled by default for a long time

--- a/pronto_biped_core/src/legodo_module.cpp
+++ b/pronto_biped_core/src/legodo_module.cpp
@@ -9,6 +9,10 @@
 namespace pronto {
 namespace biped {
 
+// Define constants for the foot joint IDs
+static const int LEFT_FOOT_JOINT_ID = 15;
+static const int RIGHT_FOOT_JOINT_ID = 16;
+
 LegOdometryModule::LegOdometryModule(const LegOdometryConfig &cfg) :
     leg_est_(new LegEstimator(cfg.odometer_cfg)),
     leg_odo_common_(new LegOdoCommon(cfg.common_cfg)),
@@ -142,11 +146,10 @@ void LegOdometryModule::updateForwardKinematics(
   // Loop over all CartesianPose entries
   for (size_t i = 0; i < fk_msg.cartesian_poses.size(); ++i) {
     const pronto_msgs::CartesianPose& cp = fk_msg.cartesian_poses[i];
-    // Check joint IDs: 15 for left foot, 16 for right foot // ANA make these global variables or input parameters
-    if (cp.joint_id == 15) {
+    if (cp.joint_id == LEFT_FOOT_JOINT_ID) {
       tf::poseMsgToTF(cp.cartesian_pose.pose, left_tf);
       left_found = true;
-    } else if (cp.joint_id == 16) {
+    } else if (cp.joint_id == RIGHT_FOOT_JOINT_ID) {
       tf::poseMsgToTF(cp.cartesian_pose.pose, right_tf);
       right_found = true;
     }

--- a/pronto_biped_ros/CMakeLists.txt
+++ b/pronto_biped_ros/CMakeLists.txt
@@ -9,13 +9,14 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   kdl_parser
   tf2_eigen
+  pronto_biped_commons
 )
 
 find_package(Eigen3 REQUIRED)
 
 catkin_package(INCLUDE_DIRS include
                LIBRARIES ${PROJECT_NAME}
-               CATKIN_DEPENDS pronto_biped_core sensor_msgs kdl_parser tf2_eigen
+               CATKIN_DEPENDS pronto_biped_core sensor_msgs kdl_parser tf2_eigen pronto_biped_commons
                DEPENDS EIGEN3)
 
 include_directories(include ${catkin_INCLUDE_DIRS})

--- a/pronto_biped_ros/include/pronto_biped_ros/yaw_lock_handler_ros.hpp
+++ b/pronto_biped_ros/include/pronto_biped_ros/yaw_lock_handler_ros.hpp
@@ -5,7 +5,7 @@
 #include <sensor_msgs/Imu.h>
 #include <ros/node_handle.h>
 #include <pronto_biped_core/yawlock_module.hpp>
-#include "pronto_biped_ros/forward_kinematics_ros.hpp"
+#include <pronto_biped_commons/forward_kinematics.hpp>
 
 namespace pronto {
 namespace biped {
@@ -29,7 +29,7 @@ public:
 
 protected:
   ros::NodeHandle& nh_;
-  std::unique_ptr<BipedForwardKinematicsROS> fk_;
+  std::unique_ptr<pronto::biped::BipedForwardKinematicsExternal> fk_;
   std::unique_ptr<YawLockModule> yawlock_module_;
   pronto::JointState joint_state_meas_;
   pronto::ImuMeasurement imu_meas_;

--- a/pronto_biped_ros/include/pronto_biped_ros/yaw_lock_handler_ros.hpp
+++ b/pronto_biped_ros/include/pronto_biped_ros/yaw_lock_handler_ros.hpp
@@ -11,7 +11,7 @@ namespace pronto {
 namespace biped {
 class YawLockHandlerROS : public DualSensingModule<sensor_msgs::Imu, sensor_msgs::JointState> {
 public:
-  YawLockHandlerROS(ros::NodeHandle& nh, std::string urdf_string);
+  YawLockHandlerROS(ros::NodeHandle& nh);
   inline virtual ~YawLockHandlerROS() {}
 
 

--- a/pronto_biped_ros/package.xml
+++ b/pronto_biped_ros/package.xml
@@ -10,8 +10,11 @@
 
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>pronto_biped_core</build_depend>
+  <build_depend>pronto_biped_commons</build_depend>
   <build_export_depend>pronto_biped_core</build_export_depend>
+  <build_export_depend>pronto_biped_commons</build_export_depend>
   <exec_depend>pronto_biped_core</exec_depend>
+  <exec_depend>pronto_biped_commons</exec_depend>
   <depend>sensor_msgs</depend>
   <depend>pronto_ros</depend>
   <depend>kdl_parser</depend>

--- a/pronto_biped_ros/src/yaw_lock_handler_ros.cpp
+++ b/pronto_biped_ros/src/yaw_lock_handler_ros.cpp
@@ -9,7 +9,7 @@
 namespace pronto {
 namespace biped {
 
-YawLockHandlerROS::YawLockHandlerROS(ros::NodeHandle &nh, std::string urdf_string)
+YawLockHandlerROS::YawLockHandlerROS(ros::NodeHandle &nh)
   : nh_(nh)
 {
   std::string prefix = "bias_lock/";

--- a/pronto_biped_ros/src/yaw_lock_handler_ros.cpp
+++ b/pronto_biped_ros/src/yaw_lock_handler_ros.cpp
@@ -66,7 +66,7 @@ YawLockHandlerROS::YawLockHandlerROS(ros::NodeHandle &nh, std::string urdf_strin
   if(!nh_.getParam(ins_param_prefix + "frame", imu_frame)){
     ROS_FATAL_STREAM("Couldn't find parameter " << ins_param_prefix << "frame");
   };
-  std::string base_frame = "base";
+  std::string base_frame = "torso";
   tf2_ros::Buffer tfBuffer;
   tf2_ros::TransformListener tf_imu_to_body_listener_(tfBuffer);
 
@@ -84,7 +84,7 @@ YawLockHandlerROS::YawLockHandlerROS(ros::NodeHandle &nh, std::string urdf_strin
     }
   }
 
-  fk_.reset(new BipedForwardKinematicsROS(urdf_string, cfg.left_standing_link, cfg.right_standing_link));
+  fk_.reset(new pronto::biped::BipedForwardKinematicsExternal(nh));
 
   yawlock_module_.reset(new YawLockModule(*fk_, cfg, ins_to_body));
 }

--- a/pronto_msgs/CMakeLists.txt
+++ b/pronto_msgs/CMakeLists.txt
@@ -11,9 +11,11 @@ add_message_files(FILES  VisualOdometryUpdate.msg
                          JointStateWithAcceleration.msg
                          LidarOdometryUpdate.msg
                          ControllerFootContact.msg
-                         BipedForceTorqueSensors.msg
                          QuadrupedForceTorqueSensors.msg
-                         VelocityWithSigmaBounds.msg)
+                         VelocityWithSigmaBounds.msg
+                         BipedCartesianPoses.msg
+                         CartesianPose.msg
+                         FootWrenches.msg)
 
 generate_messages(DEPENDENCIES std_msgs geometry_msgs)
 

--- a/pronto_msgs/msg/BipedCartesianPoses.msg
+++ b/pronto_msgs/msg/BipedCartesianPoses.msg
@@ -1,0 +1,9 @@
+#pronto_msgs/BipedCartesianPoses.msg
+
+time stamp
+
+uint32 message_id
+
+# List of all Cartesian Poses wrt root frame
+pronto_msgs/CartesianPose[] cartesian_poses
+

--- a/pronto_msgs/msg/CartesianPose.msg
+++ b/pronto_msgs/msg/CartesianPose.msg
@@ -1,0 +1,4 @@
+#pronto_msgs/CartesianPose.msg
+
+uint8 joint_id
+geometry_msgs/PoseStamped cartesian_pose

--- a/pronto_msgs/msg/FootWrenches.msg
+++ b/pronto_msgs/msg/FootWrenches.msg
@@ -1,0 +1,6 @@
+#pronto_msgs/FootWrenches.msg
+
+std_msgs/Header header
+
+geometry_msgs/Wrench left
+geometry_msgs/Wrench right

--- a/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
+++ b/pronto_ros/include/pronto_ros/pronto_ros_conversions.hpp
@@ -13,7 +13,7 @@
 #include <sensor_msgs/JointState.h>
 #include <pronto_msgs/VisualOdometryUpdate.h>
 #include <pronto_msgs/LidarOdometryUpdate.h>
-#include <pronto_msgs/BipedForceTorqueSensors.h>
+#include <pronto_msgs/FootWrenches.h>
 #include <pronto_msgs/JointStateWithAcceleration.h>
 
 namespace pronto {
@@ -57,7 +57,7 @@ void visualOdometryFromROS(const pronto_msgs::VisualOdometryUpdate& ros_msg,
 void lidarOdometryFromROS(const pronto_msgs::LidarOdometryUpdate& ros_msg,
                           LidarOdometryUpdate& msg);
 
-void forceTorqueFromROS(const pronto_msgs::BipedForceTorqueSensors& ros_msg,
+void forceTorqueFromROS(const pronto_msgs::FootWrenches& ros_msg,
                         pronto::ForceTorqueSensorArray& msg);
 
 }  // namespace pronto

--- a/pronto_ros/src/ins_ros_handler.cpp
+++ b/pronto_ros/src/ins_ros_handler.cpp
@@ -16,8 +16,8 @@ InsHandlerROS::InsHandlerROS(ros::NodeHandle &nh) : nh_(nh)
     std::string imu_frame = "imu";
 
     nh_.getParam(ins_param_prefix + "frame", imu_frame);
-    std::string base_frame = "base";
-    nh_.param<std::string>("base_link_name", base_frame, "base");
+    std::string base_frame = "torso";
+    nh_.param<std::string>("base_link_name", base_frame, "torso");
     ROS_INFO_STREAM("[InsHandlerROS] Name of base_link: '" << base_frame << "'");
     Eigen::Isometry3d ins_to_body = Eigen::Isometry3d::Identity();
     while(nh_.ok()) {

--- a/pronto_ros/src/pronto_ros_conversions.cpp
+++ b/pronto_ros/src/pronto_ros_conversions.cpp
@@ -181,45 +181,28 @@ void lidarOdometryFromROS(const pronto_msgs::LidarOdometryUpdate &ros_msg,
   msg.pose_covariance = Eigen::Map<const PoseCovariance, Eigen::Unaligned>(ros_msg.covariance.data(),6,6);
 }
 
-void forceTorqueFromROS(const pronto_msgs::BipedForceTorqueSensors& ros_msg,
+void forceTorqueFromROS(const pronto_msgs::FootWrenches& ros_msg,
                         pronto::ForceTorqueSensorArray& msg) {
-  msg.num_sensors = 4;
-  msg.names = {"l_foot", "r_foot", "l_hand", "r_hand"};
+  msg.num_sensors = 2;
   msg.utime = ros_msg.header.stamp.toNSec() * 1e-3;
   msg.sensors.resize(msg.num_sensors);
   pronto::ForceTorqueSensor ft;
   ft.utime = msg.utime;
-  ft.force[0] = ros_msg.l_foot.force.x;
-  ft.force[1] = ros_msg.l_foot.force.y;
-  ft.force[2] = ros_msg.l_foot.force.z;
-  ft.moment[0] = ros_msg.l_foot.torque.x;
-  ft.moment[1] = ros_msg.l_foot.torque.y;
-  ft.moment[2] = ros_msg.l_foot.torque.z;
+  ft.force[0] = ros_msg.left.force.x;
+  ft.force[1] = ros_msg.left.force.y;
+  ft.force[2] = ros_msg.left.force.z;
+  ft.moment[0] = ros_msg.left.torque.x;
+  ft.moment[1] = ros_msg.left.torque.y;
+  ft.moment[2] = ros_msg.left.torque.z;
   msg.sensors[0] = ft;
 
-  ft.force[0] = ros_msg.r_foot.force.x;
-  ft.force[1] = ros_msg.r_foot.force.y;
-  ft.force[2] = ros_msg.r_foot.force.z;
-  ft.moment[0] = ros_msg.r_foot.torque.x;
-  ft.moment[1] = ros_msg.r_foot.torque.y;
-  ft.moment[2] = ros_msg.r_foot.torque.z;
+  ft.force[0] = ros_msg.right.force.x;
+  ft.force[1] = ros_msg.right.force.y;
+  ft.force[2] = ros_msg.right.force.z;
+  ft.moment[0] = ros_msg.right.torque.x;
+  ft.moment[1] = ros_msg.right.torque.y;
+  ft.moment[2] = ros_msg.right.torque.z;
   msg.sensors[1] = ft;
-
-  ft.force[0] = ros_msg.l_hand.force.x;
-  ft.force[1] = ros_msg.l_hand.force.y;
-  ft.force[2] = ros_msg.l_hand.force.z;
-  ft.moment[0] = ros_msg.l_hand.torque.x;
-  ft.moment[1] = ros_msg.l_hand.torque.y;
-  ft.moment[2] = ros_msg.l_hand.torque.z;
-  msg.sensors[2] = ft;
-
-  ft.force[0] = ros_msg.r_hand.force.x;
-  ft.force[1] = ros_msg.r_hand.force.y;
-  ft.force[2] = ros_msg.r_hand.force.z;
-  ft.moment[0] = ros_msg.r_hand.torque.x;
-  ft.moment[1] = ros_msg.r_hand.torque.y;
-  ft.moment[2] = ros_msg.r_hand.torque.z;
-  msg.sensors[3] = ft;
 }
 
 }


### PR DESCRIPTION
These changes were made to enable Pronto to run on our biped:

- A new package called `pronto_biped_commons` was created to bridge my implementation with the Pronto backend
- The `BipedForwardKinematics` class was extended to a `BipedForwardKinematicsExternal` class. This subscribes to forward kinematics coming in from an external source
- Additional `pronto_msgs` were added so that `pronto` can bridge and subscribe to `fauna_msgs`
- Foot contact thresholds were tuned to our robot and added to the config file so they can be updated more easily
- A publisher was added to publish a ROS topic called `/biped/primary_foot` which contains a string indicating the primary foot in contact with the ground
- The `base_frame` name was changed to `torso` to coincide with our URDF
- Printing and logging was reduced